### PR TITLE
Fix IndexOutOfBounds for ArrayConfigItem

### DIFF
--- a/common/src/main/java/com/oroarmor/config/ArrayConfigItem.java
+++ b/common/src/main/java/com/oroarmor/config/ArrayConfigItem.java
@@ -78,6 +78,7 @@ public class ArrayConfigItem<T> extends ConfigItem<T[]> {
 
     @SuppressWarnings("unchecked")
     public void fromJson(JsonElement element) {
+        this.value = Arrays.copyOf(value, element.getAsJsonArray().size());
         for (int i = 0; i < element.getAsJsonArray().size(); i++) {
             T newValue;
             JsonElement arrayElement = element.getAsJsonArray().get(i);


### PR DESCRIPTION
### Description
Fixed IndexOutOfBounds error in ArrayConfigItem when the array in the config had more items than the default provided.

For example:
Default value = `new String[] {"Foo"}`
config was changed to
```
[
    "Foo",
    "Bar"
]